### PR TITLE
fix: update token used in our merge-to-master tagging github action

### DIFF
--- a/.github/workflows/create_tag_on_merge_to_master.yml
+++ b/.github/workflows/create_tag_on_merge_to_master.yml
@@ -15,7 +15,7 @@ jobs:
       # Clone repo with user's token. If we use GITHUB_TOKEN, it won't trigger further automation.
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.EDX_DEPLOYMENT_GH_TOKEN }}
+          token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
 
       # Tag version and push
       - name: Create tag and push


### PR DESCRIPTION
[MICROBA-1673]

When the `credentials-themes` repo transitioned to the `openedx` GitHub org this automation broke as the `openedx` org doesn't have access to the `EDX_DEPLOYMENT_GH_TOKEN` secret. This change attempts to fix the automation by using another token/user that we believe has the correct permissions.

We _can't_ use the automatically generated `GITHUB_TOKEN` as this would prevent further downstream automation from running after the version is successfully tagged. See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret.