### PR TITLE
fix: Update token used in a few more GitHub actions scripts

### DIFF
--- a/.github/workflows/create_credentials_requirements_pr.yml
+++ b/.github/workflows/create_credentials_requirements_pr.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'edx/credentials'
-          token: ${{ secrets.EDX_DEPLOYMENT_GH_TOKEN }}
+          token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
 
       # Create branch with new version and push
       - name: update version in branch
@@ -46,7 +46,7 @@ jobs:
       - name: create PR
         uses: actions/github-script@v5
         with:
-          github-token: ${{secrets.EDX_DEPLOYMENT_GH_TOKEN}}
+          github-token: ${{secrets.REQUIREMENTS_BOT_GITHUB_TOKEN}}
           script: |
             // Create credentials PR from version-updating branch above
             const createResponse = await github.rest.pulls.create({


### PR DESCRIPTION
[MICROBA-1673]

Update another one of our GitHub actions to use the `REQUIREMENTS_BOT_GITHUB_TOKEN` over `EDX_DEPLOYMENT_GH_TOKEN` (which we no longer have access to). See also: https://github.com/openedx/credentials-themes/pull/401