### PR TITLE
fix: Use new Transifex project.

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[edx-credentials-themes.djangopo]
+[credentials-themes.djangopo]
 source_file = edx_credentials_themes/locale/en/LC_MESSAGES/django.po
 source_lang = en
 type = PO


### PR DESCRIPTION
The credentials-theme Transifex project has moved to a new organization.
This updates the configuration to point to the new repository.