### PR TITLE
fix: fix team tagging issue causing the Python upgrade automation to throw an error

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -14,7 +14,7 @@ jobs:
    call-upgrade-python-requirements-workflow:
     with:
        branch: ${{ github.event.inputs.branch }}
-       team_reviewers: "edx-aperture"
+       team_reviewers: "2U-aperture"
        email_address: aperture@2u-internal.opsgenie.net
        send_success_notification: false
     secrets:


### PR DESCRIPTION
The `edx-aperture` team doesn't seem to exist anymore. I believe it may have been renamed to `2U-aperture` which would explain the reason the automation can't add the correct reviewers.