### PR TITLE
chore: add catalog-info yaml and automation that adds new PRs to repo

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,16 +1,13 @@
-name: Add New Items to Project
+name: Add New Issues to Project
 
 on:
   issues:
     types:
       - opened
-  pull_request:
-    types:
-      - opened
 
 jobs:
-  add-item-to-project:
-    name: "Add item to project"
+  add-issue-to-project:
+    name: "Add issue to project"
     uses: openedx/.github/.github/workflows/add-issue-to-a-project.yml@master
     secrets:
       GITHUB_APP_ID: ${{ secrets.GRAPHQL_AUTH_APP_ID }}

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,24 @@
+# This file records information about this repo. Its use is described in OEP-55:
+# https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0055-proc-project-maintainers.html
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: 'Credentials Themes'
+  description: 'A required package for the Credentials IDA. It provides the frontend layouts and visual styling used to render Program Certificates, Learner Records, and Program Records.'
+  links:
+    - url: 'https://github.com/openedx/credentials-themes/blob/master/README.rst'
+      title: 'Documentation'
+      icon: 'Article'
+  annotations:
+    # (Optional) Annotation keys and values can be whatever you want.
+    # We use it in Open edX repos to have a comma-separated list of GitHub user
+    # names that might be interested in changes to the architecture of this
+    # component.
+    openedx.org/arch-interest-groups: ""
+    # This can be multiple comma-separated projects.
+    openedx.org/add-to-projects: "openedx:23"
+spec:
+  type: 'service'
+  lifecycle: 'production'
+  owner: 2U-aperture
+# (Optional) An array of different components or resources.

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -18,7 +18,7 @@ metadata:
     # This can be multiple comma-separated projects.
     openedx.org/add-to-projects: "openedx:23"
 spec:
-  type: 'service'
+  type: 'library'
   lifecycle: 'production'
   owner: 2U-aperture
 # (Optional) An array of different components or resources.


### PR DESCRIPTION
This PR adds the catalog-info.yaml, which records the ownership of this repo. Its use is described in [OEP-55](https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0055-proc-project-maintainers.html)

* The OSPR bot will now add pull requests to projects if directed to by catalog-info.yaml.