### PR TITLE
chore: remove glob dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "css-loader": "5.2.7",
     "file-loader": "6.2.0",
     "font-awesome": "4.7.0",
-    "glob": "8.1.0",
     "imports-loader": "4.0.1",
     "jquery": "3.6.3",
     "mini-css-extract-plugin": "2.7.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const glob = require('glob');
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const webpack = require('webpack');
 


### PR DESCRIPTION
I was looking at a renovate PR that is trying to update `glob` from v8 --> v9. After taking another look, I realized that we aren't even using `glob` anymore. We removed its use in 2019. This PR removes `glob` from our `package.json` and removes the only use of the package in this repo.

Removed here: https://github.com/openedx/credentials-themes/commit/fbd835d3b32d084489848d5dc809253a5ce69fd5