### PR TITLE
build: update commit message used in workflow to be compliant with conventional commits

### DIFF
--- a/.github/workflows/create_credentials_requirements_pr.yml
+++ b/.github/workflows/create_credentials_requirements_pr.yml
@@ -39,7 +39,8 @@ jobs:
       - name: commit and push upgrades
         run: |
           git add requirements/
-          git commit -m "Bump credentials-themes to $RELEASE_TAG"
+          RELEASE_TAG=${GITHUB_REF#refs/tags/}
+          git commit -m "chore: bump credentials-themes to $RELEASE_TAG"
           git push --set-upstream origin edx-deployment/credentials-themes/$GITHUB_SHA
 
       # Create a PR and comment on original PR


### PR DESCRIPTION
This will fix an issue with the PRs opened automatically in Credentials (after a `credentials-themes` update) failing the "Lint commit message" check in CI.