### PR TITLE
chore: upgrade version of Python used in workflow

### DIFF
--- a/.github/workflows/create_credentials_requirements_pr.yml
+++ b/.github/workflows/create_credentials_requirements_pr.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.11"
           architecture: x64
 
       - name: upgrade requirements


### PR DESCRIPTION
[APER-3679]

Upgrades the version of Python used by the `create_credentials_requirements_pr` workflow to 3.11.

This ensures that the requirements generated for Credentials will be using the same version of Python currently configured for Credentials.