### PR TITLE
fix: revert python version to 3.12

### DIFF
--- a/.github/workflows/create_credentials_requirements_pr.yml
+++ b/.github/workflows/create_credentials_requirements_pr.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.12"
           architecture: x64
 
       - name: upgrade requirements


### PR DESCRIPTION
This PR reverts an update to the version of Python used in a GitHub action workflow from 3.13 to 3.12. This update was originally merged by the Renovate bot because it thinks it is a "minor" version upgrade.

Original commit merged by Renovate: https://github.com/openedx/credentials-themes/pull/938/commits/2d7678327d3bd10d7a800e7ca63492145b39c26c.