### PR TITLE
chore: downgrade Python version used in automation to 3.12

### DIFF
--- a/.github/workflows/create_credentials_requirements_pr.yml
+++ b/.github/workflows/create_credentials_requirements_pr.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.12"
           architecture: x64
 
       - name: upgrade requirements


### PR DESCRIPTION
Renovate is being overly helpful again and upgraded the version of Python used in the `create_credentials_requirements_pr` workflow to 3.13. This is causing issues with the Credentials IDA, as this workflow is responsible for updating all of the Credentials IDA's requirements files.