### PR TITLE
chore: removing unnecessary constraint

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,5 +10,3 @@
 
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-
-backports-zoneinfo==0.2.1; python_version < '3.9'


### PR DESCRIPTION
this constraint is for a package we no longer install, and was only necessary for Python versions we no longer install.

FIXES: APER-3294