### PR TITLE
chore: pin GitHub Actions workflows to full commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,14 @@ jobs:
         python-version: ['3.12']
         django-version: ['4.2', '5.2']
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
     - name: Setup Nodejs
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version-file: '.nvmrc'
 

--- a/.github/workflows/create_credentials_requirements_pr.yml
+++ b/.github/workflows/create_credentials_requirements_pr.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       # Clone edx/credentials
       - name: clone credentials
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: 'edx/credentials'
           token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
@@ -28,7 +28,7 @@ jobs:
           RELEASE_TAG=${GITHUB_REF#refs/tags/}
           sed -i -e "s|credentials-themes.git@.*|credentials-themes.git@$RELEASE_TAG#egg=edx_credentials_themes==$RELEASE_TAG|" requirements/base.in
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
           architecture: x64
@@ -45,7 +45,7 @@ jobs:
 
       # Create a PR and comment on original PR
       - name: create PR
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{secrets.REQUIREMENTS_BOT_GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/create_tag_on_merge_to_master.yml
+++ b/.github/workflows/create_tag_on_merge_to_master.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Clone repo with user's token. If we use GITHUB_TOKEN, it won't trigger further automation.
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
 

--- a/.github/workflows/patch_version_on_requirements_update.yml
+++ b/.github/workflows/patch_version_on_requirements_update.yml
@@ -14,7 +14,7 @@ jobs:
     if: startsWith( github.head_ref, 'jenkins/upgrade-python-requirements' )
     steps:
       # Clone repo
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Pins all `uses:` action refs to their full commit SHA with the version tag preserved as a comment. Part of org-wide SHA-pinning migration: openedx/.github#165